### PR TITLE
fix: игнорировать дельты с пустым текстом в StreamingChatModel

### DIFF
--- a/langchain4j-gigachat/src/main/java/chat/giga/langchain4j/GigaChatStreamingChatModel.java
+++ b/langchain4j-gigachat/src/main/java/chat/giga/langchain4j/GigaChatStreamingChatModel.java
@@ -212,9 +212,10 @@ public class GigaChatStreamingChatModel implements StreamingChatModel {
                                 event.messages().forEach(message -> {
                                     if (message.content() != null) {
                                         message.content().forEach(part -> {
-                                            if (part.text() != null) {
-                                                text.append(part.text());
-                                                handler.onPartialResponse(part.text());
+                                            String partText = part.text();
+                                            if (partText != null && !partText.isEmpty()) {
+                                                text.append(partText);
+                                                handler.onPartialResponse(partText);
                                             }
                                             if (part.functionCall() != null) {
                                                 var functionCall = part.functionCall();
@@ -305,9 +306,10 @@ public class GigaChatStreamingChatModel implements StreamingChatModel {
         responseMetadataBuilder.modelName(chatCompletionChunk.model());
 
         chatCompletionChunk.choices().forEach(choice -> {
-            if (choice.delta().content() != null) {
-                text.append(choice.delta().content());
-                handler.onPartialResponse(choice.delta().content());
+            String content = choice.delta().content();
+            if (content != null && !content.isEmpty()) {
+                text.append(content);
+                handler.onPartialResponse(content);
             }
             if (choice.finishReason() == ChoiceFinishReason.FUNCTION_CALL) {
                 toolExecutionRequests.add(toToolExecutionRequest(choice));

--- a/langchain4j-gigachat/src/test/java/chat/giga/langchain4j/GigaChatChatStreamingModelTest.java
+++ b/langchain4j-gigachat/src/test/java/chat/giga/langchain4j/GigaChatChatStreamingModelTest.java
@@ -10,7 +10,6 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import dev.langchain4j.data.message.UserMessage;
 import dev.langchain4j.model.chat.request.ChatRequest;
 import dev.langchain4j.model.chat.request.DefaultChatRequestParameters;
-import dev.langchain4j.model.chat.request.json.JsonSchema;
 import dev.langchain4j.model.chat.response.ChatResponse;
 import dev.langchain4j.model.chat.response.StreamingChatResponseHandler;
 import org.junit.jupiter.api.BeforeEach;
@@ -92,5 +91,39 @@ public class GigaChatChatStreamingModelTest {
         assertThat(responseCaptorFinal.getValue().finishReason().name().toLowerCase()).isEqualTo(
                 body.choices().get(0).finishReason().value());
 
+    }
+
+    @Test
+    void shouldSkipEmptyPartialContent() {
+        var emptyBody = TestData.completionChunkEmptyContentResponse();
+        var contentBody = TestData.completionChunkContentOnlyResponse("hello");
+
+        doAnswer(i -> {
+            var listener = i.getArgument(1, SseListener.class);
+            listener.onError(new HttpClientException(401, null));
+            return null;
+        }).doAnswer(i -> {
+            var listener = i.getArgument(1, SseListener.class);
+            listener.onData(objectMapper.writeValueAsString(emptyBody));
+            listener.onData(objectMapper.writeValueAsString(contentBody));
+            listener.onComplete();
+            return null;
+        }).when(httpClient).execute(any(), any(SseListener.class));
+
+        model.chat(
+                ChatRequest.builder()
+                        .messages(new UserMessage("test"))
+                        .parameters(DefaultChatRequestParameters.builder().modelName(ModelName.GIGA_CHAT_PRO)
+                                .build())
+                        .build(),
+                completionChunkResponseHandler);
+
+        var responseCaptor = ArgumentCaptor.forClass(String.class);
+        verify(completionChunkResponseHandler, timeout(300)).onPartialResponse(responseCaptor.capture());
+        verify(completionChunkResponseHandler, after(100).never()).onPartialResponse("");
+        verify(completionChunkResponseHandler, timeout(100)).onCompleteResponse(any());
+        verify(completionChunkResponseHandler, after(100).never()).onError(any());
+
+        assertThat(responseCaptor.getAllValues()).containsExactly("hello");
     }
 }

--- a/langchain4j-gigachat/src/test/java/chat/giga/langchain4j/TestData.java
+++ b/langchain4j-gigachat/src/test/java/chat/giga/langchain4j/TestData.java
@@ -48,6 +48,37 @@ public class TestData {
                 .build();
     }
 
+    public static CompletionChunkResponse completionChunkEmptyContentResponse() {
+        return CompletionChunkResponse.builder()
+                .choice(ChoiceChunk.builder()
+                        .delta(ChoiceMessageChunk.builder()
+                                .role(ASSISTANT)
+                                .content("")
+                                .build())
+                        .index(0)
+                        .build())
+                .created(3214)
+                .model("testModel")
+                .object("test")
+                .build();
+    }
+
+    public static CompletionChunkResponse completionChunkContentOnlyResponse(String content) {
+        return CompletionChunkResponse.builder()
+                .choice(ChoiceChunk.builder()
+                        .delta(ChoiceMessageChunk.builder()
+                                .role(ASSISTANT)
+                                .content(content)
+                                .build())
+                        .index(0)
+                        .finishReason(ChoiceFinishReason.STOP)
+                        .build())
+                .created(3214)
+                .model("testModel")
+                .object("test")
+                .build();
+    }
+
     public static CompletionChunkResponse completionChunkNullFieldsResponse() {
         return CompletionChunkResponse.builder()
                 .choice(ChoiceChunk.builder()


### PR DESCRIPTION
## Проблема
В стриминге GigaChat иногда приходят дельты с пустым текстом (`content: ""` / пустой `part.text()`).
LangChain4j `PartialResponse` не принимает null/empty → падение стрима:
`IllegalArgumentException: text cannot be null or empty`.

## Исправление
Не вызывать `handler.onPartialResponse(...)` для пустого текста в обоих путях:
- v1 `handlePartialResponse` (completion chunks)
- v2 `onMessageDelta` (части сообщения)

## Тест
- `shouldSkipEmptyPartialContent` — пустой chunk, затем `"hello"`; проверка, что `onPartialResponse("")` не вызывался